### PR TITLE
New features for dgroc

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -76,6 +76,9 @@ building the source rpm.
 ``copr`` The optional name of the copr repository to build the package within.
 When not set, the project name (from `[]`) is used.
 
+``archive_cmd`` Alternative command to generate source archive. This command
+needs to print the name of the generated archive to stdout.
+
 .. Note:: The spec file should be fully functionnal as all ``dgroc`` will do is
           update the ``Source0``, ``Release`` and add an entry in the ``Changelog``.
 

--- a/README.rst
+++ b/README.rst
@@ -29,9 +29,6 @@ Get it running
     username = me
     email = my_email@example.com
     copr_url = https://copr.fedoraproject.org/
-    upload_command = cp %s /var/www/html/subsurface/
-    upload_url = http://my_server/subsurface/%s
-    #no_ssl_check = True  # No longer required now that copr has a valid cert
 
     [subsurface]
     git_url = git://subsurface.hohndel.org/subsurface.git
@@ -56,24 +53,6 @@ it.
 it.
 
 ``copr_url`` The url of `copr`_ to use.
-
-``upload_command`` The command to run to make the source rpm (src.rpm, srpm)
-available to copr. This can be a copy command (cp) or a copy over ssh (scp).
-Note that the ``%s`` is important, it will be replaced by the full path to
-the source rpm created.
-
-`upload_url` The url of the source rpm once it has been uploaded. Note that
-here as well the ``%s`` is important as it will be replaced by the source
-rpm file name.
-
-For example, if you upload your source rpm onto your fedorapeople space, your
-``upload_command`` might be: ``scp %s fedorapeople:public_html/srpms/`` and
-your ``upload_url`` might be: ``https://pingou.fedorapeople.org/srpms/%s``.
-
-``no_ssl_check`` Simple boolean to check the ssl certificate when starting
-the build on copr. At the moment the ssl certificate is self-signed and thus
-invalid. So using the ``https`` version of ``copr_url`` will require a
-``no_ssl_check`` set to ``True``.
 
 
 The project section
@@ -112,7 +91,7 @@ From the sources, it requires few steps:
 
 * Install dependencies::
 
-    yum install libgit2-devel python-virtualenvwrapper
+    dnf install libgit2-devel python-virtualenvwrapper python-copr
 
 * Create a virtual env::
 


### PR DESCRIPTION
I started using dgroc to daily build some of my projects and found few problems/missing features. I think my changes could be useful for others too.

Changes:
- python-copr support. It's easier to use (from python) than the API and it could upload the SRPMs to copr directly.
- Custom command for creating source archive. Just creating an archive from git (mercurial) is often not enough -- it might be necessary to run some autogen/configure magic etc.
- Updating spec files from upstream repository. If the project is already packaged in Fedora and it has its spec file in the repository, it might be useful to update "our" spec file when there is a version change -- so the version (+ build number) in copr is always greater than version available from Fedora repos.
