### PR TITLE
More minor fixes

### DIFF
--- a/dgroc.py
+++ b/dgroc.py
@@ -35,7 +35,7 @@ except ImportError:
 
 
 DEFAULT_CONFIG = os.path.expanduser('~/.config/dgroc')
-COPR_URL = 'http://copr.fedoraproject.org/'
+COPR_URL = 'https://copr.fedorainfracloud.org/'
 # Initial simple logging stuff
 logging.basicConfig(format='%(message)s')
 LOG = logging.getLogger("dgroc")

--- a/dgroc.py
+++ b/dgroc.py
@@ -1,4 +1,5 @@
-#-*- coding: utf-8 -*-
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
 
 """
  (c) 2014 - Copyright Red Hat Inc


### PR DESCRIPTION
 * Add a shebang so the file can be executed directly (e.g. when installed somewhere on `$PATH`)
 * Fix default COPR url: the old one responds with 302 Moved Permanently redirect, which a `POST` request will not follow.