### PR TITLE
Allow configuring copr config file

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -75,6 +75,10 @@ the build on copr. At the moment the ssl certificate is self-signed and thus
 invalid. So using the ``https`` version of ``copr_url`` will require a
 ``no_ssl_check`` set to ``True``.
 
+``copr_config`` The path to a config file with details about COPR connection.
+Go to the API page on your COPR instance to get the contents. This is useful if
+you want to use dgroc with different copr instances. Defaults to
+``~/.config/copr``.
 
 The project section
 -------------------

--- a/dgroc.py
+++ b/dgroc.py
@@ -114,13 +114,14 @@ class MercurialReader(object):
            "%s/%s" % (get_rpm_sourcedir(), archive_name)]
 
 
-def _get_copr_auth():
+def _get_copr_auth(copr_file):
     ''' Return the username, login and API token from the copr configuration
     file.
     '''
     LOG.debug('Reading configuration for copr')
     ## Copr config check
-    copr_config_file = os.path.expanduser('~/.config/copr')
+    copr_file = copr_file or '~/.config/copr'
+    copr_config_file = os.path.expanduser(copr_file)
     if not os.path.exists(copr_config_file):
         raise DgrocException('No `~/.config/copr` file found.')
 
@@ -446,7 +447,8 @@ def copr_build(config, srpms):
             "certificate when submitting the builds to copr")
         insecure = config.get('main', 'no_ssl_check')
 
-    username, login, token = _get_copr_auth()
+    copr_config = config.get('main', 'copr_config', None)
+    username, login, token = _get_copr_auth(copr_config)
 
     build_ids = []
     # Build project/srpm in copr
@@ -521,7 +523,8 @@ def check_copr_build(config, build_ids):
             "certificate when submitting the builds to copr")
         insecure = config.get('main', 'no_ssl_check')
 
-    username, login, token = _get_copr_auth()
+    copr_config = config.get('main', 'copr_config', None)
+    username, login, token = _get_copr_auth(copr_config)
 
     build_ip = []
     ## Build project/srpm in copr


### PR DESCRIPTION
When using multiple COPR instances, we need to use a different config file for each. This patch adds a `copr_config` directive to the main section.